### PR TITLE
EnumNames

### DIFF
--- a/Source/Core/GBSwagger.Model.Attributes.pas
+++ b/Source/Core/GBSwagger.Model.Attributes.pas
@@ -89,6 +89,14 @@ type
     property dateFormat: string read FdateFormat;
   end;
 
+  SwagEnumNames = class(TCustomAttribute)
+  private
+    FNames: TArray<string>;
+  public
+    constructor Create(const ANames: string);
+    property Names: TArray<string> read FNames write FNames;
+  end;
+
 implementation
 
 { SwagClass }
@@ -157,6 +165,13 @@ end;
 constructor SwagIgnore.create;
 begin
 
+end;
+
+{ SwagEnumNames }
+
+constructor SwagEnumNames.Create(const ANames: string);
+begin
+  FNames := ANames.Split([',']);
 end;
 
 end.

--- a/Source/Core/GBSwagger.RTTI.pas
+++ b/Source/Core/GBSwagger.RTTI.pas
@@ -225,19 +225,26 @@ var
   i : Integer;
   unitName: string;
   enumName: string;
+  enumNamesAtt: SwagEnumNames;
 begin
-  unitName := PropertyType.QualifiedName.Replace('.' + PropertyType.ToString, EmptyStr);
-  i        := 0;
+  enumNamesAtt := GetAttribute<SwagEnumNames>;
+  if Assigned(enumNamesAtt) then
+    Result := enumNamesAtt.Names
+  else
+  begin
+    unitName := PropertyType.QualifiedName.Replace('.' + PropertyType.ToString, EmptyStr);
+    i        := 0;
 
-  repeat
-    enumName := GetEnumName(TGBSwaggerRTTI.GetInstance.FindType(PropertyType.QualifiedName).Handle, i);
-    if not enumName.Equals(unitName) then
-    begin
-      SetLength(result, i + 1);
-      result[i] := enumName;
-      i := i + 1;
-    end;
-  until enumName.Equals(unitName);
+    repeat
+      enumName := GetEnumName(TGBSwaggerRTTI.GetInstance.FindType(PropertyType.QualifiedName).Handle, i);
+      if not enumName.Equals(unitName) then
+      begin
+        SetLength(result, i + 1);
+        result[i] := enumName;
+        i := i + 1;
+      end;
+    until enumName.Equals(unitName);
+  end;
 end;
 
 function TGBSwaggerRTTIPropertyHelper.GetListType(AObject: TObject): TRttiType;


### PR DESCRIPTION
alteração pra poder colocar uma anotação em field enum alterando os nomes do enum.
Exemplo de uso: [SwagEnumNames('Mercadoria para revenda,Matéria prima,Embalagem,Produto em processo,Produto acabado,Serviço,Outros')] por exemplo