### PR TITLE
Allow swagger to use by default the current access protocol

### DIFF
--- a/Source/Core/GBSwagger.Model.pas
+++ b/Source/Core/GBSwagger.Model.pas
@@ -389,12 +389,6 @@ end;
 function TGBSwaggerModel.Protocols: TArray<TGBSwaggerProtocol>;
 begin
   result := FProtocols.ToArray;
-
-  if Length(result) = 0 then
-  begin
-    SetLength(result, 1);
-    result[0] := gbHttp;
-  end;
 end;
 
 function TGBSwaggerModel.Register: IGBSwaggerRegister;


### PR DESCRIPTION
Or by definition in the docs:
`If schemes are not specified, the scheme used to serve the API specification will be used for API calls.`

https://swagger.io/docs/specification/2-0/api-host-and-base-path/