### PR TITLE
Fixing for `TArray<T>` serialization on JSON

### DIFF
--- a/Source/Core/GBSwagger.JSON.V2.Schema.pas
+++ b/Source/Core/GBSwagger.JSON.V2.Schema.pas
@@ -62,7 +62,7 @@ begin
         Result.AddPair(LProperty.SwagName, JSONProperty(LProperty))
   end;
 
-  // Excluir Swagger Ignore em caso de herança
+  // Excluir Swagger Ignore em caso de heranÃ§a
   for LProperty in FSchema.ClassType.GetProperties do
     if LProperty.IsSwaggerIgnore(FSchema.ClassType) then
     begin
@@ -139,9 +139,15 @@ begin
 end;
 
 function TGBSwaggerJSONV2Schema.JSONPropertyPairArray(AProperty: TRttiProperty): TJSONPair;
+var
+  LClassType: TClass;
+  LClassName: string;
 begin
+  LClassType := AProperty.GetArrayClassType;
+  LClassName := FSchema.&End.SchemaName(LClassType);
+
   Result := TJSONPair.Create('items', TJSONObject.Create
-    .AddPair('type', AProperty.ArrayType));
+    .AddPair('$ref', '#/definitions/' + LClassName));
 end;
 
 function TGBSwaggerJSONV2Schema.JSONPropertyPairEnum(AProperty: TRttiProperty): TJSONPair;

--- a/Source/Core/GBSwagger.RTTI.pas
+++ b/Source/Core/GBSwagger.RTTI.pas
@@ -57,8 +57,8 @@ type
     function IsTime: Boolean;
     function IsBoolean: Boolean;
 
-    // Vários ORMs trabalham com tipo Nullable
-    // Colaboração do Giorgio para essa compatibilidade
+    // VÃ¡rios ORMs trabalham com tipo Nullable
+    // ColaboraÃ§Ã£o do Giorgio para essa compatibilidade
     function IsNullable: Boolean;
     function NullableType: string;
 
@@ -83,6 +83,7 @@ type
     function SwagMaxLength: Integer;
 
     function GetClassType: TClass;
+    function GetArrayClassType: TClass;
     function GetListType(AObject: TObject): TRttiType;
     function GetEnumNames: TArray<string>;
   end;
@@ -201,6 +202,13 @@ begin
 end;
 
 { TGBSwaggerRTTIPropertyHelper }
+
+function TGBSwaggerRTTIPropertyHelper.GetArrayClassType: TClass;
+begin
+  Result := nil;
+  if (IsArray) then
+    Result := TRttiInstanceType(TRttiDynamicArrayType(Self.PropertyType).ElementType).MetaclassType;
+end;
 
 function TGBSwaggerRTTIPropertyHelper.ArrayType: string;
 begin


### PR DESCRIPTION
Assuming the following simplified sample classes:

```delphi
type
  TProduto = class
  private
    FIdentificador: string;
  published
    property Identificador: string read FIdentificador write FIdentificador;
  end;

  TItem = class
  private
    FProduto: TProduto;
  published
    property Produto: TProduto read FProduto write FProduto;
  end;

  TEntidadeEntrada = class(TBaseJsonEntidade)
  private
    [JSONName('itens')]
    FItensArray: TArray<TItem>;
  public
    property Itens: TArray<TItem> read FItensArray;
  end;
```

And defining the swagger as follows:

```delphi
Swagger
    .AddModel(TProduto)
    .AddModel(TItem)
    .AddModel(TEntidadeEntrada);

  Swagger
    .Path('/my-path')
      .POST('Sample', 'Sample description')
        .AddParamBody('Request data', 'The request data to be processed')
          .Required(True)
          .Schema(TEntidadeEntrada)
        .&End
        .AddResponse(THTTPStatus.OK.ToInteger, 'Success').&End
      .&End
    .&End;
```

We end up with `Unknown Type: TItem` for the `TArray<TItem>` (both on endpoint and models definitions).

![image](https://github.com/user-attachments/assets/0a20ae1e-7975-46d1-a5cc-c315257756e0)

![image](https://github.com/user-attachments/assets/7d97a291-a567-4655-a924-10cab36e54f4)

**That happens because the json array is getting serialized as:**

```json
"Itens": {
    "type": "array",
    "items": {
        "type": "TItem"
    }
}
```

instead of:

```json
"Itens": {
    "type": "array",
    "items": {
        "$ref": "#\/definitions\/Item"
    }
}
```

**With the suggested fix, the array gets serialized correctly on the json (therefore, on models and endpoints definitions).**

![image](https://github.com/user-attachments/assets/45d89cc8-d460-492b-bb6e-b0c7652e52d5)

![image](https://github.com/user-attachments/assets/3de76ff5-0b6f-4120-bc52-f5fefad93647)
