### PR TITLE
SwagInfo added and fix SwagProp

### DIFF
--- a/Samples/Horse/annotations/Annotation.Classes.pas
+++ b/Samples/Horse/annotations/Annotation.Classes.pas
@@ -14,7 +14,9 @@ type
     FBirthdayDate: TDateTime;
     FLastUpdate: TDateTime;
   public
-    [SwagProp('user id', True)]
+    //[SwagProp('user id', True)]
+    [SwagInfo('user id')]
+    [SwagRequired]
     property Id: Double read FId write FId;
 
     [SwagProp('User Description', True)]

--- a/Source/Core/GBSwagger.Model.Attributes.pas
+++ b/Source/Core/GBSwagger.Model.Attributes.pas
@@ -28,6 +28,14 @@ type
   SwagRequired = class(TCustomAttribute)
   end;
 
+  SwagInfo = class(TCustomAttribute)
+  private
+    FDescription: string;
+  public
+    constructor Create(ADescription: string); overload;
+    property Description: string read FDescription;
+  end;
+
   SwagIgnore = class(TCustomAttribute)
   private
     FIgnoreProperties: TArray<string>;
@@ -168,6 +176,13 @@ end;
 
 constructor SwagIgnore.Create;
 begin
+end;
+
+{ SwagDescription }
+
+constructor SwagInfo.Create(ADescription: string);
+begin
+  FDescription := ADescription;
 end;
 
 end.

--- a/Source/Core/GBSwagger.RTTI.pas
+++ b/Source/Core/GBSwagger.RTTI.pas
@@ -1,4 +1,4 @@
-unit GBSwagger.RTTI;
+ï»¿unit GBSwagger.RTTI;
 
 interface
 
@@ -57,8 +57,8 @@ type
     function IsTime: Boolean;
     function IsBoolean: Boolean;
 
-    // Vários ORMs trabalham com tipo Nullable
-    // Colaboração do Giorgio para essa compatibilidade
+    // Vï¿½rios ORMs trabalham com tipo Nullable
+    // Colaboraï¿½ï¿½o do Giorgio para essa compatibilidade
     function IsNullable: Boolean;
     function NullableType: string;
 
@@ -779,7 +779,10 @@ begin
     if (Assigned(LSwaggerRequired)) then
     begin
       SetLength(Result, Length(Result) + 1);
-      Result[Length(Result) - 1] := LProp.Name;
+      case TGBSwaggerModelConfig.GetInstance(nil).CaseDefinition of
+        cdLower: Result[Length(Result) - 1]  := LProp.Name.ToLower;
+        cdUpper: Result[Length(Result) - 1]  := LProp.Name.ToUpper;
+      end;
       Continue;
     end;
 

--- a/Source/Core/GBSwagger.RTTI.pas
+++ b/Source/Core/GBSwagger.RTTI.pas
@@ -481,12 +481,18 @@ end;
 
 function TGBSwaggerRTTIPropertyHelper.SwagDescription: string;
 var
+  LSwaggerDescription: SwagInfo;
   LSwaggerProp: SwagProp;
 begin
   Result := EmptyStr;
+  LSwaggerDescription := self.GetAttribute<SwagInfo> ;
+  if assigned(LSwaggerDescription) then
+    result := LSwaggerDescription.Description;
+
   LSwaggerProp := Self.GetAttribute<SwagProp>;
   if Assigned(LSwaggerProp) then
     Result := LSwaggerProp.description;
+
 end;
 
 function TGBSwaggerRTTIPropertyHelper.SwagMaxLength: Integer;


### PR DESCRIPTION
Adicionado a classe SwagInfo para informar apenas a descrição da propriedade no model, pois na versão 3.1.0 se usar o SwagProp é necessário informar o nome da propriedade manualmente.  E corrigido nome da propriedade com swagRequerid com case definition configurado.